### PR TITLE
Lower case for 'glymur' package name in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 
-kwargs = {'name': 'Glymur',
+kwargs = {'name': 'glymur',
           'description': 'Tools for accessing JPEG2000 files',
           'long_description': open('README.md').read(),
           'author': 'John Evans',


### PR DESCRIPTION
Is there a reason for different capitalization?
