### PR TITLE
Update function renamed in skimage 0.16.

### DIFF
--- a/docs/source/how_do_i.rst
+++ b/docs/source/how_do_i.rst
@@ -83,13 +83,13 @@ Values must be increasing, but the last value may be 0 to indicate
 the layer is lossless.  However, the OpenJPEG library will reorder
 the layers to make the first layer lossless, not the last. ::
 
-    >>> import skimage.data, skimage.measure, glymur
+    >>> import skimage.data, skimage.metrics, glymur
     >>> truth = skimage.data.camera()
     >>> jp2 = glymur.Jp2k('myfile.jp2', data=truth, psnr=[30, 40, 50, 0])
     >>> psnr = []
     >>> for layer in range(4):
     ...     jp2.layer = layer
-    ...     psnr.append(skimage.measure.compare_psnr(truth, jp2[:]))
+    ...     psnr.append(skimage.metrics.peak_signal_noise_ratio(truth, jp2[:]))
     >>> print(psnr)
     [inf, 29.028560403833303, 39.206919416670402, 47.593129828702246]
 

--- a/tests/test_jp2k.py
+++ b/tests/test_jp2k.py
@@ -26,7 +26,7 @@ from lxml import etree as ET
 import numpy as np
 try:
     import skimage.data
-    import skimage.measure
+    import skimage.metrics
     _HAVE_SCIKIT_IMAGE = True
 except ModuleNotFoundError:
     _HAVE_SCIKIT_IMAGE = False
@@ -1307,7 +1307,7 @@ class TestJp2k_write(fixtures.MetadataBase):
             # warning
             warnings.simplefilter('ignore')
             psnr = [
-                skimage.measure.compare_psnr(skimage.data.camera(), d[j])
+                skimage.metrics.peak_signal_noise_ratio(skimage.data.camera(), d[j])
                 for j in range(4)
             ]
 


### PR DESCRIPTION
`test_psnr` fails with skimage 0.18 because `skimage.measure.compare_psnr` was renamed to `skimage.metrics.peak_signal_noise_ratio` in [0.16](https://github.com/scikit-image/scikit-image/blob/master/doc/source/api_changes.md#version-016).
```
======================================================================
ERROR: test_psnr (tests.test_jp2k.TestJp2k_write)
SCENARIO:  Four peak signal-to-noise ratio values are supplied, the
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/tests/test_jp2k.py", line 1309, in test_psnr
    psnr = [
  File "/<<PKGBUILDDIR>>/tests/test_jp2k.py", line 1310, in <listcomp>
    skimage.measure.compare_psnr(skimage.data.camera(), d[j])
AttributeError: module 'skimage.measure' has no attribute 'compare_psnr'

----------------------------------------------------------------------
Ran 468 tests in 44.506s
```