### PR TITLE
Changed np.int to int as per deprecationWarning from numpy

### DIFF
--- a/glymur/jp2k.py
+++ b/glymur/jp2k.py
@@ -1081,7 +1081,7 @@ class Jp2k(Jp2kBox):
         if np.abs(np.log2(step) - np.round(np.log2(step))) > 1e-6:
             msg = "Row and column strides must be powers of 2."
             raise ValueError(msg)
-        rlevel = np.int(np.round(np.log2(step)))
+        rlevel = int(np.round(np.log2(step)))
 
         area = (0 if rows.start is None else rows.start,
                 0 if cols.start is None else cols.start,


### PR DESCRIPTION
Numpy 1.20 gives the following message when using Glymur:

> 
> glymur/jp2k.py:1084: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
> Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
>   rlevel = np.int(np.round(np.log2(step)))

This PR fixes the code as per numpy's recommendation.