### PR TITLE
Add missing “packaging” dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ packages = find:
 install_requires =
     numpy
     lxml
+    packaging
     setuptools
 python_requires = >=3.7
 include_package_data = True


### PR DESCRIPTION
Fixes `ImportError` at:

https://github.com/quintusdias/glymur/blob/8789b39ecf681e44be52b883c70175fa0c3e3413/glymur/version.py#L15