### PR TITLE
Remove setuptools from runtime requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ install_requires =
     numpy
     lxml
     packaging
-    setuptools
 python_requires = >=3.7
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
With the switch to packaging, there is no setuptools runtime requirement. You only need it for building, which is sufficiently stated here:

https://github.com/quintusdias/glymur/blob/2ee8f27a5f260f8e577cf6aaf88e07d12ea7f2c1/pyproject.toml#L2