### PR TITLE
Fix typo in changelog (wrong version number)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-September 12, 2022 - v0.11.5
+September 12, 2022 - v0.11.6
     Fix reads where COD segment not at index[2]
     This fix not included in 0.11.5
 


### PR DESCRIPTION
The version number `v0.11.5` was copy-pasted from the previous entry.