### PR TITLE
Adapt to OrderedDict repr change in Python 3.12

### DIFF
--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -3,6 +3,7 @@
 Test suite for printing.
 """
 # Standard library imports ...
+from collections import OrderedDict
 import importlib.resources as ir
 from io import BytesIO, StringIO
 import struct
@@ -1058,6 +1059,9 @@ class TestPrinting(fixtures.TestCommon):
 
             actual = str(j.box[5])
 
+        # Python 3.12: gh-101446: Change repr of collections.OrderedDict
+        # https://github.com/python/cpython/pull/101661
+        exif_val = OrderedDict([('Make', 'HTC')])
         expected = (
             "UUID Box (uuid) @ (1135519, 142)\n"
             "    UUID:  4a706754-6966-6645-7869-662d3e4a5032 (EXIF)\n"
@@ -1066,7 +1070,7 @@ class TestPrinting(fixtures.TestCommon):
             "                    (   'TileOffsets',\n"
             "                        "
             "array([ 0, 10, 20, ..., 70, 80, 90], dtype=uint32)),\n"
-            "                    ('ExifTag', OrderedDict([('Make', 'HTC')]))])"
+            f"                    ('ExifTag', {exif_val!r})])"
         )
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
https://github.com/python/cpython/pull/101661

Fixes, on Python 3.12.0b3:

```
E       AssertionError: "UUID[304 chars]                 ('ExifTag', OrderedDict({'Make': 'HTC'}))])" != "UUID[304 chars]                 ('ExifTag', OrderedDict([('Make', 'HTC')]))])"
E         UUID Box (uuid) @ (1135519, 142)
E             UUID:  4a706754-6966-6645-7869-662d3e4a5032 (EXIF)
E             UUID Data:  OrderedDict([   ('ImageWidth', 256),
E                             ('ImageLength', 512),
E                             (   'TileOffsets',
E                                 array([ 0, 10, 20, ..., 70, 80, 90], dtype=uint32)),
E       -                     ('ExifTag', OrderedDict({'Make': 'HTC'}))])
E       ?                                             ^      ^      ^
E       +                     ('ExifTag', OrderedDict([('Make', 'HTC')]))])
E       ?                                             ^^      ^      ^^
tests/test_printing.py:1071: AssertionError
=========================== short test summary info ============================
FAILED tests/test_printing.py::TestPrinting::test_exif_uuid - AssertionError:...
================== 1 failed, 605 passed, 1 skipped in 51.41s ===================
```

Downstream bug: https://bugzilla.redhat.com/show_bug.cgi?id=2220255