### PR TITLE
Add API reference to docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,9 @@
+#############
+API reference
+#############
+
+.. autoclass:: glymur.Jp2k
+    :members:
+
+.. autoclass:: glymur.jp2box.Jp2kBox
+    :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -269,3 +269,5 @@ texinfo_documents = [('index', 'glymur', 'glymur Documentation',
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
+
+numpydoc_show_class_members = False

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ Contents:
    introduction
    detailed_installation
    how_do_i
+   api
    whatsnew/index
    roadmap
 
@@ -26,4 +27,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-


### PR DESCRIPTION
I often find myself looking into the source code for `Jp2k` to work out what the different parameters etc. mean. I thought it might be helpful to add an API reference page to the docs to make this information more discoverable.