### PR TITLE
Depend on the maintained Pillow package, not the archived PIL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = 'Read and write JPEG 2000 files'
 dependencies = [
     'numpy',
     'lxml',
-    'PIL',
+    'pillow',
 ]
 keywords = ['JPEG2000', 'JPEG', '2000', 'imagery']
 license = 'MIT'


### PR DESCRIPTION
The new hard dependency on `PIL` for `import PIL` corresponds to the original PIL, https://pypi.org/project/PIL/, which last had a release in 2006 and has been archived for many years. The correct dependency is `pillow`, https://pypi.org/project/pillow/, the fork that replaced the original PIL, and which also provides `import PIL`.