### PR TITLE
Adjust two test regexes for Python 3.14

### DIFF
--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -1694,7 +1694,7 @@ class TestJp2dump(fixtures.TestCommon):
             actual = fake_out.getvalue().strip()
 
         expected = (
-            "<class 'glymur.lib.openjp2.ImageType'>:\n"
+            "<class 'glymur\\.lib\\.openjp2\\.ImageType'>:\n"
             "    x0: 0\n"
             "    y0: 0\n"
             "    x1: 0\n"
@@ -1702,7 +1702,7 @@ class TestJp2dump(fixtures.TestCommon):
             "    numcomps: 0\n"
             "    color_space: 0\n"
             "    icc_profile_buf: "
-            "<(glymur.lib.openjp2|ctypes.wintypes).LP_c_ubyte "
+            "<(glymur\\.lib\\.openjp2|ctypes\\.wintypes)\\.LP_c_ubyte "
             "object at 0x[0-9A-Fa-f]*>\n"
             "    icc_profile_len: 0")
         self.assertRegex(actual, expected)
@@ -1712,7 +1712,7 @@ class TestJp2dump(fixtures.TestCommon):
         obj = opj2.ImageCompType()
         actual = str(obj)
         expected = (
-            "<class 'glymur.lib.openjp2.ImageCompType'>:\n"
+            "<class 'glymur\\.lib\\.openjp2\\.ImageCompType'>:\n"
             "    dx: 0\n"
             "    dy: 0\n"
             "    w: 0\n"
@@ -1725,7 +1725,7 @@ class TestJp2dump(fixtures.TestCommon):
             "    resno_decoded: 0\n"
             "    factor: 0\n"
             "    data: "
-            "<(glymur.lib.openjp2|ctypes.wintypes).LP_c_(int|long) "
+            "<(glymur\\.lib\\.openjp2|ctypes\\.wintypes)\\.LP_c_(int|long) "
             "object at 0x[a-fA-F0-9]+>\n"
             "    alpha: 0\n"
         )

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -1702,7 +1702,7 @@ class TestJp2dump(fixtures.TestCommon):
             "    numcomps: 0\n"
             "    color_space: 0\n"
             "    icc_profile_buf: "
-            "<(glymur\\.lib\\.openjp2|ctypes\\.wintypes)\\.LP_c_ubyte "
+            "<(glymur\\.lib\\.openjp2|ctypes(\\.wintypes)?)\\.LP_c_ubyte "
             "object at 0x[0-9A-Fa-f]*>\n"
             "    icc_profile_len: 0")
         self.assertRegex(actual, expected)
@@ -1725,7 +1725,7 @@ class TestJp2dump(fixtures.TestCommon):
             "    resno_decoded: 0\n"
             "    factor: 0\n"
             "    data: "
-            "<(glymur\\.lib\\.openjp2|ctypes\\.wintypes)\\.LP_c_(int|long) "
+            "<(glymur\\.lib\\.openjp2|ctypes(\\.wintypes)?)\\.LP_c_(int|long) "
             "object at 0x[a-fA-F0-9]+>\n"
             "    alpha: 0\n"
         )

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -1673,16 +1673,17 @@ class TestJp2dump(fixtures.TestCommon):
         with patch('sys.stdout', new=StringIO()) as fake_out:
             print(icpt)
             actual = fake_out.getvalue().strip()
-        expected = ("<class 'glymur.lib.openjp2.ImageComptParmType'>:\n"
-                    "    dx: 0\n"
-                    "    dy: 0\n"
-                    "    w: 0\n"
-                    "    h: 0\n"
-                    "    x0: 0\n"
-                    "    y0: 0\n"
-                    "    prec: 0\n"
-                    "    bpp: 0\n"
-                    "    sgnd: 0")
+        expected = (
+            "<class 'glymur.lib.openjp2.ImageComptParmType'>:\n"
+            "    dx: 0\n"
+            "    dy: 0\n"
+            "    w: 0\n"
+            "    h: 0\n"
+            "    x0: 0\n"
+            "    y0: 0\n"
+            "    prec: 0\n"
+            "    bpp: 0\n"
+            "    sgnd: 0")
         self.assertEqual(actual, expected)
 
     def test_default_image_type(self):
@@ -1700,7 +1701,9 @@ class TestJp2dump(fixtures.TestCommon):
             "    y1: 0\n"
             "    numcomps: 0\n"
             "    color_space: 0\n"
-            "    icc_profile_buf: <(glymur.lib.openjp2|ctypes.wintypes).LP_c_ubyte object at 0x[0-9A-Fa-f]*>\n"  # noqa : E501
+            "    icc_profile_buf: "
+            "<(glymur.lib.openjp2|ctypes.wintypes).LP_c_ubyte "
+            "object at 0x[0-9A-Fa-f]*>\n"
             "    icc_profile_len: 0")
         self.assertRegex(actual, expected)
 
@@ -1709,22 +1712,22 @@ class TestJp2dump(fixtures.TestCommon):
         obj = opj2.ImageCompType()
         actual = str(obj)
         expected = (
-            r'''<class 'glymur.lib.openjp2.ImageCompType'>:\n'''
-            '''    dx: 0\n'''
-            '''    dy: 0\n'''
-            '''    w: 0\n'''
-            '''    h: 0\n'''
-            '''    x0: 0\n'''
-            '''    y0: 0\n'''
-            '''    prec: 0\n'''
-            '''    bpp: 0\n'''
-            '''    sgnd: 0\n'''
-            '''    resno_decoded: 0\n'''
-            '''    factor: 0\n'''
-            '''    data: '''
-            '''<(glymur.lib.openjp2|ctypes.wintypes).LP_c_(int|long) '''
-            '''object at 0x[a-fA-F0-9]+>\n'''
-            '''    alpha: 0\n'''
+            "<class 'glymur.lib.openjp2.ImageCompType'>:\n"
+            "    dx: 0\n"
+            "    dy: 0\n"
+            "    w: 0\n"
+            "    h: 0\n"
+            "    x0: 0\n"
+            "    y0: 0\n"
+            "    prec: 0\n"
+            "    bpp: 0\n"
+            "    sgnd: 0\n"
+            "    resno_decoded: 0\n"
+            "    factor: 0\n"
+            "    data: "
+            "<(glymur.lib.openjp2|ctypes.wintypes).LP_c_(int|long) "
+            "object at 0x[a-fA-F0-9]+>\n"
+            "    alpha: 0\n"
         )
         self.assertRegex(actual, expected)
 


### PR DESCRIPTION
The key change here for Python 3.14 is:

```diff
--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -1702,7 +1702,7 @@ def test_default_image_type(self):
             "    numcomps: 0\n"
             "    color_space: 0\n"
             "    icc_profile_buf: "
-            "<(glymur\\.lib\\.openjp2|ctypes\\.wintypes)\\.LP_c_ubyte "
+            "<(glymur\\.lib\\.openjp2|ctypes(\\.wintypes)?)\\.LP_c_ubyte "
             "object at 0x[0-9A-Fa-f]*>\n"
             "    icc_profile_len: 0")
         self.assertRegex(actual, expected)
@@ -1725,7 +1725,7 @@ def test_image_comp_type(self):
             "    resno_decoded: 0\n"
             "    factor: 0\n"
             "    data: "
-            "<(glymur\\.lib\\.openjp2|ctypes\\.wintypes)\\.LP_c_(int|long) "
+            "<(glymur\\.lib\\.openjp2|ctypes(\\.wintypes)?)\\.LP_c_(int|long) "
             "object at 0x[a-fA-F0-9]+>\n"
             "    alpha: 0\n"
         )
```

However, I tidied up the formatting of these expected-representation regexes a bit first to make them more consistent with each other, and (to be formally correct) I backslash-escaped literal periods so they only match the actual period character.